### PR TITLE
Swap previous and next links

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,7 +10,7 @@ exports.createPages = ({ graphql, actions }) => {
         `
           query {
             allMarkdownRemark(
-              sort: { order: DESC, fields: [frontmatter___date] }
+              sort: { order: ASC, fields: [frontmatter___date] }
             ) {
               edges {
                 node {

--- a/src/templates/project-page.js
+++ b/src/templates/project-page.js
@@ -31,7 +31,7 @@ const ProjectPage = ({ data, pageContext }) => {
             <Link to={previous.fields.slug} className="group">
               <div className="flex items-center gap-x-2 text-gray-500">
                 <ArrowNarrowLeftIcon className="w-5 h-5" />
-                Next
+                Previous
               </div>
               <p className="mt-4 uppercase text-green-600 font-bold text-xs tracking-wide">
                 {previous.frontmatter.location}
@@ -47,7 +47,7 @@ const ProjectPage = ({ data, pageContext }) => {
             <div className="mt-6 sm:mt-0">
               <Link to={next.fields.slug} className="group sm:text-right">
                 <div className="flex items-center gap-x-2 text-gray-500 sm:justify-end">
-                  Previous
+                  Next
                   <ArrowNarrowRightIcon className="w-5 h-5" />
                 </div>
                 <p className="mt-4 uppercase text-green-600 font-bold text-xs tracking-wide">


### PR DESCRIPTION
Usually previous links are on the left side of the screen and next links are on the right side of the screen (similar to the back and forward functionality of web browsers). This fixes that.